### PR TITLE
Avoid redefinition warning

### DIFF
--- a/core/shared/platform/zephyr/platform_internal.h
+++ b/core/shared/platform/zephyr/platform_internal.h
@@ -286,7 +286,9 @@ typedef struct timespec os_timespec;
 #define CLOCK_REALTIME 1
 #endif
 
+#ifndef CLOCK_MONOTONIC
 #define CLOCK_MONOTONIC 4
+#endif
 
 static inline int
 os_sched_yield(void)


### PR DESCRIPTION
CLOCK_MONOTONIC is defined in Zephyr, so only define it if it does not exist. I believe this was added in the 4.X branch. Without this, a ton of warnings are generated about redefining the symbol.