### PR TITLE
Zephyr POSIX file improvements

### DIFF
--- a/core/shared/platform/common/posix/posix_convert_stat.c
+++ b/core/shared/platform/common/posix/posix_convert_stat.c
@@ -1,0 +1,79 @@
+#include "platform_api_extension.h"
+
+// Converts a POSIX timespec to a WASI timestamp.
+__wasi_timestamp_t
+static posix_convert_timespec(const struct timespec *ts)
+{
+    if (ts->tv_sec < 0)
+        return 0;
+    if ((__wasi_timestamp_t)ts->tv_sec >= UINT64_MAX / 1000000000)
+        return UINT64_MAX;
+    return (__wasi_timestamp_t)ts->tv_sec * 1000000000
+           + (__wasi_timestamp_t)ts->tv_nsec;
+}
+
+// Converts a POSIX stat structure to a WASI filestat structure
+void
+posix_convert_stat(os_file_handle handle, const struct stat *in,
+             __wasi_filestat_t *out)
+{
+    out->st_dev = in->st_dev;
+    out->st_ino = in->st_ino;
+    out->st_nlink = (__wasi_linkcount_t)in->st_nlink;
+    out->st_size = (__wasi_filesize_t)in->st_size;
+#ifdef __APPLE__
+    out->st_atim = posix_convert_timespec(&in->st_atimespec);
+    out->st_mtim = posix_convert_timespec(&in->st_mtimespec);
+    out->st_ctim = posix_convert_timespec(&in->st_ctimespec);
+#else
+    out->st_atim = posix_convert_timespec(&in->st_atim);
+    out->st_mtim = posix_convert_timespec(&in->st_mtim);
+    out->st_ctim = posix_convert_timespec(&in->st_ctim);
+#endif
+
+    // Convert the file type. In the case of sockets there is no way we
+    // can easily determine the exact socket type.
+    if (S_ISBLK(in->st_mode)) {
+        out->st_filetype = __WASI_FILETYPE_BLOCK_DEVICE;
+    }
+    else if (S_ISCHR(in->st_mode)) {
+        out->st_filetype = __WASI_FILETYPE_CHARACTER_DEVICE;
+    }
+    else if (S_ISDIR(in->st_mode)) {
+        out->st_filetype = __WASI_FILETYPE_DIRECTORY;
+    }
+    else if (S_ISFIFO(in->st_mode)) {
+        out->st_filetype = __WASI_FILETYPE_SOCKET_STREAM;
+    }
+    else if (S_ISLNK(in->st_mode)) {
+        out->st_filetype = __WASI_FILETYPE_SYMBOLIC_LINK;
+    }
+    else if (S_ISREG(in->st_mode)) {
+        out->st_filetype = __WASI_FILETYPE_REGULAR_FILE;
+    }
+    else if (S_ISSOCK(in->st_mode)) {
+        int socktype;
+        socklen_t socktypelen = sizeof(socktype);
+
+        if (getsockopt(handle, SOL_SOCKET, SO_TYPE, &socktype, &socktypelen)
+            < 0) {
+            out->st_filetype = __WASI_FILETYPE_UNKNOWN;
+            return;
+        }
+
+        switch (socktype) {
+            case SOCK_DGRAM:
+                out->st_filetype = __WASI_FILETYPE_SOCKET_DGRAM;
+                break;
+            case SOCK_STREAM:
+                out->st_filetype = __WASI_FILETYPE_SOCKET_STREAM;
+                break;
+            default:
+                out->st_filetype = __WASI_FILETYPE_UNKNOWN;
+                return;
+        }
+    }
+    else {
+        out->st_filetype = __WASI_FILETYPE_UNKNOWN;
+    }
+}

--- a/core/shared/platform/common/posix/posix_convert_stat.h
+++ b/core/shared/platform/common/posix/posix_convert_stat.h
@@ -1,0 +1,6 @@
+#include "platform_api_extension.h"
+
+// Converts a POSIX stat structure to a WASI filestat structure
+void
+posix_convert_stat(os_file_handle handle, const struct stat *in,
+             __wasi_filestat_t *out);

--- a/core/shared/platform/zephyr/shared_platform.cmake
+++ b/core/shared/platform/zephyr/shared_platform.cmake
@@ -15,13 +15,15 @@ if(${CONFIG_MINIMAL_LIBC})
     set (source_all ${source_all} ${PLATFORM_COMMON_MATH_SOURCE})
 endif()
 
+list(APPEND source_all ${PLATFORM_SHARED_DIR}/../common/posix/posix_convert_stat.c)
+
 if (NOT WAMR_BUILD_LIBC_WASI EQUAL 1)
     list(REMOVE_ITEM source_all ${PLATFORM_SHARED_DIR}/zephyr_socket.c)
     list(REMOVE_ITEM source_all ${PLATFORM_SHARED_DIR}/zephyr_file.c)
     list(REMOVE_ITEM source_all ${PLATFORM_SHARED_DIR}/zephyr_clock.c)
 else()
-  include (${CMAKE_CURRENT_LIST_DIR}/../common/libc-util/platform_common_libc_util.cmake)
-  set(source_all ${source_all} ${PLATFORM_COMMON_LIBC_UTIL_SOURCE})
+    include (${CMAKE_CURRENT_LIST_DIR}/../common/libc-util/platform_common_libc_util.cmake)
+    set(source_all ${source_all} ${PLATFORM_COMMON_LIBC_UTIL_SOURCE})
 endif ()
 
 set (PLATFORM_SHARED_SOURCE ${source_all})


### PR DESCRIPTION
This is the first step in moving the zephyr integration to be as POSIX as possible.

Since in Zephyr now, sockets and files use regular file descriptors, we just need these hacks for directory file descriptors.

We change most functions from using the proprietary Zephyr API to the POSIX.